### PR TITLE
Sync floating window background with IP status

### DIFF
--- a/TrayApp/main.py
+++ b/TrayApp/main.py
@@ -214,7 +214,9 @@ def update_float_window(ip, _):
         float_window.label.config(text=ip)
         correct = ip == target_ip
         display_color = 'green' if correct else 'red'
-        float_window.label.config(bg=display_color)
+        fg_color = 'black' if correct else 'white'
+        float_window.configure(bg=display_color)
+        float_window.label.config(bg=display_color, fg=fg_color)
         if not correct:
             float_window.attributes("-alpha", 1.0)
             notified = True


### PR DESCRIPTION
## Summary
- Keep floating IP window's background in sync with IP status color.
- Adjust label foreground color (black on green, white on red) for readability.

## Testing
- `python -m py_compile TrayApp/main.py`
- `python test_update_float_window.py` *(simulated IP changes to verify colors and tray icon)*

------
https://chatgpt.com/codex/tasks/task_e_68948eddf72c832fa9e5a9f2b0d60af5